### PR TITLE
Fix the sample to run. Cheers :)

### DIFF
--- a/MinimalApi/Controllers/WeatherForecastController.cs
+++ b/MinimalApi/Controllers/WeatherForecastController.cs
@@ -35,6 +35,10 @@ public class WeatherForecastController : ControllerBase
     [Route("ValidateParams")]
     public IActionResult ValidateParams(ParamsRequest request)
     {
-        return Ok();
+        // You need to check ModelState
+        // and respond accordingly, typically with BadRequest
+        return ModelState.IsValid 
+            ? Ok() 
+            : BadRequest(ModelState);
     }
 }

--- a/MinimalApi/MinimalApi.csproj
+++ b/MinimalApi/MinimalApi.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.1.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>

--- a/MinimalApi/Program.cs
+++ b/MinimalApi/Program.cs
@@ -1,12 +1,18 @@
-using System.Reflection;
 using FluentValidation;
+using FluentValidation.AspNetCore;
+using Validators;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
-builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+
+// NuGet Package: FluentValidation.AspNetCore
+builder.Services.AddFluentValidation();
+
+// Be sure to add the correct validator assembly
+builder.Services.AddValidatorsFromAssembly(typeof(ParamsRequest).Assembly);
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
Most of the fixes are in `Program.cs`

1. You need the NuGet package `FluentValidation.AspNetCore` if you plan on using the ASP.NET Core pipeline to do your validation. If not, you'll have to inject the `IValidator<T>` and validate requests manually. Calling `AddFluentValidation` sets up the validator factory for use with FluentValidation.
2. Since your validators are in another assembly, you can't use `Assembly.GetExecutingAssembly()`. You need the assembly that contains your validators.
3. Your endpoints (or action filters) still need to check `ModelState` and respond accordingly. It doesn't happen automatically. :)

Cheers :)

- Khalid (@khalidabuhakmeh)

<img width="1256" alt="Screenshot 2022-08-04 at 09 13 57" src="https://user-images.githubusercontent.com/228256/182855787-b793618e-1010-4300-97e1-3e5f80e702c5.png">
